### PR TITLE
SerialMonitor.cs: Added Request To Send Handshake & Data Terminal Rea…

### DIFF
--- a/SerialMonitor.cs
+++ b/SerialMonitor.cs
@@ -38,7 +38,9 @@ namespace RetroSpy
         {
             _printerMode = printerMode;
             _localBuffer = new List<byte>();
-            _datPort = new SerialPort(portName != null ? portName.Split(' ')[0] : "", useLagFix ? 57600 : BAUD_RATE);
+-           _datPort = new SerialPort(portName != null ? portName.Split(' ')[0] : "", useLagFix ? 57600 : BAUD_RATE);
+-           _datPort.Handshake = Handshake.RequestToSend; // Improves support for devices expecting RTS & DTR signals.
+-           _datPort.DtrEnable = true;
         }
 
         public void Start()


### PR DESCRIPTION
This is a version of an implementation of the NicoHood/Nintendo Library support that is in the current master of NintedoSpy
Written by [robertvanderaarde](https://github.com/jaburns/NintendoSpy/commits?author=robertvanderaarde) committed on Sep 2, 2019 

Gamecube.cs: 
Added support for NicoHood/Nintendo 8 byte serial format.

This also adds support for certain devices that expect handshakes.
Written by [ClydePowers](https://github.com/jaburns/NintendoSpy/commits?author=ClydePowers) committed on Aug 25, 2020 and Myself [Skuzee](https://github.com/jaburns/NintendoSpy/commits?author=Skuzee) committed on Mar 7, 2020

SerialMonitor.cs:
Added Request To Send Handshake & Data Terminal Ready = True.  
Improves connection/re-connection with certain devices. atgema32u4 (arduino pro micro)
