### PR TITLE
Nintendo64.cs: added support for nicohood byte packet format

### DIFF
--- a/Readers/Nintendo64.cs
+++ b/Readers/Nintendo64.cs
@@ -5,9 +5,14 @@ namespace RetroSpy.Readers
     public static class Nintendo64
     {
         private const int PACKET_SIZE = 32;
-
+        private const int NICOHOOD_PACKET_SIZE = 4;
+                
         private static readonly string[] BUTTONS = {
             "a", "b", "z", "start", "up", "down", "left", "right", null, null, "l", "r", "cup", "cdown", "cleft", "cright"
+        };
+
+        private static readonly string[] NICOHOOD_BUTTONS = {
+            "right", "left", "down", "up", "start", "z", "b", "a", "cright", "cleft", "cdown", "cup", "r", "l", null, null
         };
 
         private static float ReadStick(byte input)
@@ -21,6 +26,24 @@ namespace RetroSpy.Readers
             {
                 throw new ArgumentNullException(nameof(packet));
             }
+
+                if (packet.Length == NICOHOOD_PACKET_SIZE) // Packets are written as bytes when writing from the NicoHood API, so we're looking for a packet size of 4 (interpreted as bytes)
+                {
+
+                    ControllerStateBuilder stateNico = new ControllerStateBuilder();
+
+                    for (int i = 0; i < 16; i++) // Handles the two button bytes
+                    {
+                        if (string.IsNullOrEmpty(NICOHOOD_BUTTONS[i])) continue;
+                        int bitPacket = (packet[i / 8] >> (i % 8)) & 0x1;
+                        stateNico.SetButton(NICOHOOD_BUTTONS[i], bitPacket != 0x00);
+                    }
+
+                    stateNico.SetAnalog("stick_x", ReadStick(packet[2]),packet[2]);
+                    stateNico.SetAnalog("stick_y", ReadStick(packet[3]),packet[3]);
+
+                    return stateNico.Build();
+                }
 
             if (packet.Length != PACKET_SIZE)
             {


### PR DESCRIPTION
This is the same thing I did for the gamecube reader. I added support for a n64 4 byte package format, and support for the nicohood library button order. (since the bytes are reversed).

I'm kind of surprised that nintendospy/retrospy's default format is sending data with ASCII 1s/0s, and not whole bytes. I guess at this point keeping reverse compatibility is a good thing.

Thanks for taking a look at my addition! 💛 