### PR TITLE
Make SerialMonitor updates much more frequently

### DIFF
--- a/SerialMonitor.cs
+++ b/SerialMonitor.cs
@@ -58,7 +58,7 @@ namespace RetroSpy
 
             _datPort.Open();
 
-            _timer = new DispatcherTimer
+            _timer = new DispatcherTimer(DispatcherPriority.Normal)
             {
                 Interval = TimeSpan.FromMilliseconds(TIMER_MS)
             };


### PR DESCRIPTION
Change SerialMonitor timer priority to 'Normal', reflecting gamepad state in the ui much faster than default (background) priority. Before, I observed an avg of ~60ms between reads, with p80 at ~300ms between reads using the background priority. When changing to normal, it averaged more like 16ms between reads.

Anecdotally, the UI looks much more snappy, updating quick button presses in the UI to match what I'm doing on the controller. As a kaizo speedrunner, I'm missing far fewer inputs, which makes me happy :)

Data snippet of epoch tick ms from reads before the change:
```
1669261480769|
1669261480790|
1669261480809|
1669261481008|
1669261481289|
1669261481305|
1669261481321|
1669261481337|
1669261481352|
1669261481383|
1669261481510|
1669261481525|
1669261481541|
```

Data snippet of epoch tick ms from reads after the change :
```
1669260765779|
1669260765810|
1669260765826|
1669260765841|
1669260765856|
1669260765868|
1669260765887|
1669260765902|
1669260765918|
```
