### PR TITLE
Add Raspberry Pi Pico support

### DIFF
--- a/RetroSpyX/SetupWindow.axaml.cs
+++ b/RetroSpyX/SetupWindow.axaml.cs
@@ -687,6 +687,7 @@ namespace RetroSpy
                 {
                     List<string> arduinoPorts = SetupCOMPortInformation();
                     GetTeensyPorts(arduinoPorts);
+                    GetRaspberryPiPorts(arduinoPorts);
 
                     arduinoPorts.Sort();
 
@@ -787,6 +788,44 @@ namespace RetroSpy
                                 //board = PJRC_Board.unknown;
                                 break;
                         }
+                    }
+                }
+            }
+        }
+
+        private static void GetRaspberryPiPorts(List<string> arduinoPorts)
+        {
+            const uint vid = 0x2E8A;
+            string vidStr = "'%USB_VID[_]" + vid.ToString("X", CultureInfo.CurrentCulture) + "%'";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                using ManagementObjectSearcher searcher = new("root\\CIMV2", "SELECT * FROM Win32_PnPEntity WHERE DeviceID LIKE " + vidStr);
+                foreach (ManagementBaseObject mgmtObject in searcher.Get())
+                {
+                    string[] DeviceIdParts = ((string)mgmtObject["PNPDeviceID"]).Split("\\".ToArray());
+                    if (DeviceIdParts[0] != "USB")
+                    {
+                        break;
+                    }
+
+                    int start = DeviceIdParts[1].IndexOf("PID_", StringComparison.Ordinal) + 4;
+                    uint pid = Convert.ToUInt32(DeviceIdParts[1].Substring(start, 4), 16);
+
+                    string port;
+                    if (((string)mgmtObject["Caption"]).Split("()".ToArray()).Length > 2)
+                        port = ((string)mgmtObject["Caption"]).Split("()".ToArray())[1];
+                    else
+                        continue;
+
+                    switch (pid)
+                    {
+                        case 0x000A:
+                            arduinoPorts.Add(port + " (Raspberry Pi Pico)");
+                            break;
+
+                        default:
+                            break;
                     }
                 }
             }

--- a/firmware/sketches/AmigaAnalog.cpp
+++ b/firmware/sketches/AmigaAnalog.cpp
@@ -26,7 +26,7 @@
 
 #include "AmigaAnalog.h"
 
-#if !(defined(__arm__) && defined(CORE_TEENSY)) && !defined(ARDUINO_AVR_NANO_EVERY)
+#if !(defined(__arm__) && defined(CORE_TEENSY)) && !defined(ARDUINO_AVR_NANO_EVERY) && !defined(RASPBERRYPI_PICO)
 
 static volatile int lastVal = 0;
 static volatile int analogVal = 0;

--- a/firmware/sketches/AmigaMouse.cpp
+++ b/firmware/sketches/AmigaMouse.cpp
@@ -26,7 +26,7 @@
 
 #include "AmigaMouse.h"
 
-#if !(defined(__arm__) && defined(CORE_TEENSY)) && !defined(ARDUINO_AVR_NANO_EVERY)
+#if !(defined(__arm__) && defined(CORE_TEENSY)) && !defined(ARDUINO_AVR_NANO_EVERY) && !defined(RASPBERRYPI_PICO)
 
 static byte buttons[3];
 static int8_t currentX;

--- a/firmware/sketches/Atari5200.cpp
+++ b/firmware/sketches/Atari5200.cpp
@@ -26,7 +26,7 @@
 
 #include "Atari5200.h"
 
-#if !(defined(__arm__) && defined(CORE_TEENSY)) && !defined(ARDUINO_AVR_NANO_EVERY)
+#if !(defined(__arm__) && defined(CORE_TEENSY)) && !defined(ARDUINO_AVR_NANO_EVERY) && !defined(RASPBERRYPI_PICO)
 
 static volatile int lastVal = 0;
 static volatile int currentVal = 0;

--- a/firmware/sketches/AtariPaddles.cpp
+++ b/firmware/sketches/AtariPaddles.cpp
@@ -26,7 +26,7 @@
 
 #include "AtariPaddles.h"
 
-#if !(defined(__arm__) && defined(CORE_TEENSY)) && !defined(ARDUINO_AVR_NANO_EVERY)
+#if !(defined(__arm__) && defined(CORE_TEENSY)) && !defined(ARDUINO_AVR_NANO_EVERY) && !defined(RASPBERRYPI_PICO)
 
 static int nominal_min = 1024;
 static int nominal_max = 0;

--- a/firmware/sketches/CDiKeyboard.cpp
+++ b/firmware/sketches/CDiKeyboard.cpp
@@ -26,7 +26,7 @@
 
 #include "CDiKeyboard.h"
 
-#if !defined(TP_PINCHANGEINTERRUPT) && !(defined(__arm__) && defined(CORE_TEENSY))
+#if !defined(TP_PINCHANGEINTERRUPT) && !(defined(__arm__) && defined(CORE_TEENSY)) && !defined(RASPBERRYPI_PICO)
 
 // Backspace == Delete
 static byte lookup[128] = {

--- a/firmware/sketches/ControllerSpy.h
+++ b/firmware/sketches/ControllerSpy.h
@@ -48,7 +48,9 @@ public:
 		delay(1000);		
 	}
 	
+	virtual void setup1() {}
 	virtual void loop() = 0;
+	virtual void loop1() {}
 	virtual void writeSerial() = 0;
 	virtual void debugSerial() = 0;
 	virtual void updateState() = 0;

--- a/firmware/sketches/FMTowns.cpp
+++ b/firmware/sketches/FMTowns.cpp
@@ -26,7 +26,7 @@
 
 #include "FMTowns.h"
 
-#if !(defined(__arm__) && defined(CORE_TEENSY))
+#if !(defined(__arm__) && defined(CORE_TEENSY)) && !defined(RASPBERRYPI_PICO)
 
 void FMTownsSpy::loop() {
 	noInterrupts();

--- a/firmware/sketches/Intellivision.cpp
+++ b/firmware/sketches/Intellivision.cpp
@@ -26,7 +26,7 @@
 
 #include "Intellivision.h"
 
-#if !(defined(__arm__) && defined(CORE_TEENSY))
+#if !(defined(__arm__) && defined(CORE_TEENSY)) && !defined(RASPBERRYPI_PICO)
 
 const unsigned char IntellivisionSpy::buttonMasks[32] = {
 			0b01000000, 0b01000001, 0b01100001, 0b01100000, 0b00100000, 0b00100001, 0b00110001, 0b00110000,

--- a/firmware/sketches/Jaguar.cpp
+++ b/firmware/sketches/Jaguar.cpp
@@ -26,7 +26,7 @@
 
 #include "Jaguar.h"
 
-#if !(defined(__arm__) && defined(CORE_TEENSY))
+#if !(defined(__arm__) && defined(CORE_TEENSY)) && !defined(RASPBERRYPI_PICO)
 
 void JaguarSpy::loop() {
 	noInterrupts();

--- a/firmware/sketches/SNES.cpp
+++ b/firmware/sketches/SNES.cpp
@@ -26,26 +26,43 @@
 
 #include "SNES.h"
 
-#if defined(ARDUINO_TEENSY35) || defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_NANO) || defined(ARDUINO_AVR_NANO_EVERY) || defined(ARDUINO_AVR_LARDU_328E)
+#if defined(ARDUINO_TEENSY35) || defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_NANO) || defined(ARDUINO_AVR_NANO_EVERY) || defined(ARDUINO_AVR_LARDU_328E) || defined(RASPBERRYPI_PICO)
 
 void SNESSpy::loop() {
+#if !defined(RASPBERRYPI_PICO)
+	loop1();
+#endif
+
+	if (sendRequest)
+	{
+		sendBytes = bytesToReturn;
+		memcpy(sendData, rawData, SNES_BITCOUNT_EXT);
+		sendRequest = false;
+#ifdef DEBUG
+		debugSerial();
+#else
+		writeSerial();
+#endif
+		T_DELAY(5);
+	}
+}
+
+void SNESSpy::loop1() {
+	while (sendRequest)
+	{
+	}
 	noInterrupts();
 	updateState();
 	interrupts();
-#if !defined(DEBUG)
-	writeSerial();
-#else
-	debugSerial();
-#endif
-	T_DELAY(5);
+	sendRequest = true;
 }
 
 void SNESSpy::writeSerial() {
-	sendRawData(rawData, 0, bytesToReturn);
+	sendRawData(sendData, 0, sendBytes);
 }
 
 void SNESSpy::debugSerial() {
-	sendRawDataDebug(rawData, 0, bytesToReturn);
+	sendRawDataDebug(sendData, 0, sendBytes);
 }
 
 void SNESSpy::updateState() {

--- a/firmware/sketches/SNES.cpp
+++ b/firmware/sketches/SNES.cpp
@@ -28,6 +28,17 @@
 
 #if defined(ARDUINO_TEENSY35) || defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_NANO) || defined(ARDUINO_AVR_NANO_EVERY) || defined(ARDUINO_AVR_LARDU_328E) || defined(RASPBERRYPI_PICO)
 
+void SNESSpy::setup1() {
+#if defined(RASPBERRYPI_PICO)
+	// Disable the built-in pull-up and pull-down resistors and input the signals divided by 10kƒ¶ and 20kƒ¶ external resistors.
+	// If the resistance value used for voltage division is too low,
+	// SNES and RetroSpy will recognize that all buttons are being pressed when no controller is connected.
+	pinMode(SNES_LATCH, INPUT);
+	pinMode(SNES_DATA,  INPUT);
+	pinMode(SNES_CLOCK, INPUT);
+#endif
+}
+
 void SNESSpy::loop() {
 #if !defined(RASPBERRYPI_PICO)
 	loop1();

--- a/firmware/sketches/SNES.h
+++ b/firmware/sketches/SNES.h
@@ -39,6 +39,7 @@
 class SNESSpy : public ControllerSpy {
 public:
 	void loop();
+	void loop1();
 	void writeSerial();
 	void debugSerial();
 	void updateState();
@@ -48,6 +49,9 @@ public:
 private:
 	unsigned char rawData[SNES_BITCOUNT_EXT];
 	unsigned char bytesToReturn = SNES_BITCOUNT;
+    unsigned char sendData[SNES_BITCOUNT_EXT];
+    unsigned char sendBytes = SNES_BITCOUNT;
+    volatile bool sendRequest = false;
 };
 
 #endif

--- a/firmware/sketches/SNES.h
+++ b/firmware/sketches/SNES.h
@@ -38,6 +38,7 @@
 
 class SNESSpy : public ControllerSpy {
 public:
+	void setup1();
 	void loop();
 	void loop1();
 	void writeSerial();

--- a/firmware/sketches/TG16.cpp
+++ b/firmware/sketches/TG16.cpp
@@ -26,7 +26,7 @@
 
 #include "TG16.h"
 
-#if !(defined(__arm__) && defined(CORE_TEENSY))
+#if !(defined(__arm__) && defined(CORE_TEENSY)) && !defined(RASPBERRYPI_PICO)
 
 void TG16Spy::loop() {
 

--- a/firmware/sketches/ThreeDO.cpp
+++ b/firmware/sketches/ThreeDO.cpp
@@ -26,7 +26,7 @@
 
 #include "ThreeDO.h"
 
-#if !(defined(__arm__) && defined(CORE_TEENSY))
+#if !(defined(__arm__) && defined(CORE_TEENSY)) && !defined(RASPBERRYPI_PICO)
 
 void ThreeDOSpy::setup(uint8_t cableType) {
 	this->cableType = cableType;

--- a/firmware/sketches/Wii.h
+++ b/firmware/sketches/Wii.h
@@ -29,6 +29,12 @@
 
 #include "ControllerSpy.h"
 
+#if defined(RASPBERRYPI_PICO)
+typedef uint32_t port_t;
+#else
+typedef uint8_t port_t;
+#endif
+
 class WiiSpy : public ControllerSpy {
 public:
 	void setup();
@@ -39,8 +45,8 @@ public:
 	const char* startupMsg();
 
 private:
-	uint8_t   current_portb = 0;
-	uint8_t   last_portb;
+	port_t    current_port = 0;
+	port_t    last_port;
 	int       i2c_index = 0;
 	bool      isControllerPoll = false;
 	bool      isControllerID = false;

--- a/firmware/sketches/Wii.h
+++ b/firmware/sketches/Wii.h
@@ -38,7 +38,9 @@ typedef uint8_t port_t;
 class WiiSpy : public ControllerSpy {
 public:
 	void setup();
+	void setup1();
 	void loop();
+	void loop1();
 	void writeSerial();
 	void debugSerial();
 	void updateState();
@@ -56,6 +58,8 @@ private:
 	byte      keyThing[8];
 	byte      cleanData[274];
 	byte      rawData[16000];
+	byte      sendData[51];
+	volatile bool sendRequest = false;
 };
 
 #endif

--- a/firmware/sketches/common.cpp
+++ b/firmware/sketches/common.cpp
@@ -58,7 +58,7 @@ void common_pin_setup()
 	pinMode(17, INPUT_PULLUP);
 	pinMode(19, INPUT_PULLUP);
 	pinMode(18, INPUT_PULLUP);
-#else
+#elif !defined(RASPBERRYPI_PICO)
 	PORTD = 0x00;
 	PORTB = 0x00;
 	DDRD = 0x00;

--- a/firmware/sketches/common.h
+++ b/firmware/sketches/common.h
@@ -32,6 +32,8 @@
 #include "config_teensy.h"
 #elif defined(ARDUINO_AVR_NANO_EVERY)
 #include "config_every.h"
+#elif defined(RASPBERRYPI_PICO)
+#include "config_pico.h"
 #else
 #include "config_arduino.h"
 #endif

--- a/firmware/sketches/config_pico.h
+++ b/firmware/sketches/config_pico.h
@@ -31,4 +31,8 @@
 #define T_DELAY( ms ) delay(0)
 #define A_DELAY( ms ) delay(0)
 
+#define SNES_LATCH         17
+#define SNES_DATA          16
+#define SNES_CLOCK         18
+
 #define FASTRUN

--- a/firmware/sketches/config_pico.h
+++ b/firmware/sketches/config_pico.h
@@ -26,7 +26,7 @@
 
 #define PIND_READ( pin ) (gpio_get(pin))
 
-#define MICROSECOND_NOPS ""
+#define MICROSECOND_NOPS "nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\n"
 
 #define T_DELAY( ms ) delay(0)
 #define A_DELAY( ms ) delay(0)

--- a/firmware/sketches/config_pico.h
+++ b/firmware/sketches/config_pico.h
@@ -24,12 +24,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#define PINC_READ( pin ) (gpio_get(pin))
 #define PIND_READ( pin ) (gpio_get(pin))
 
 #define MICROSECOND_NOPS "nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\n"
 
 #define T_DELAY( ms ) delay(0)
 #define A_DELAY( ms ) delay(0)
+
+#define MODEPIN_SNES       10
+#define MODEPIN_WII        9
 
 #define SNES_LATCH         17
 #define SNES_DATA          16

--- a/firmware/sketches/config_pico.h
+++ b/firmware/sketches/config_pico.h
@@ -1,10 +1,10 @@
 //
-// PCFX.cpp
+// config_pico.h
 //
 // Author:
-//       Christopher "Zoggins" Mallery <zoggins@retro-spy.com>
+//       T.T <tt3333@tt-server.net>
 //
-// Copyright (c) 2020 RetroSpy Technologies
+// Copyright (c) 2022 RetroSpy Technologies
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,54 +24,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "PCFX.h"
+#define PIND_READ( pin ) (gpio_get(pin))
 
-#if !(defined(__arm__) && defined(CORE_TEENSY)) && !defined(RASPBERRYPI_PICO)
+#define MICROSECOND_NOPS ""
 
-void PCFXSpy::loop() {
-	noInterrupts();
-	updateState();
-	interrupts();
-#if !defined(DEBUG)
-	writeSerial();
-#else
-	debugSerial();
-#endif
-}
+#define T_DELAY( ms ) delay(0)
+#define A_DELAY( ms ) delay(0)
 
-void PCFXSpy::updateState() {
-	unsigned char bits = PCFX_BITCOUNT;
-	unsigned char *rawDataPtr = rawData;
-
-	WAIT_FALLING_EDGE(PCFX_LATCH);
-
-	do {
-		WAIT_FALLING_EDGE(PCFX_CLOCK);
-		*rawDataPtr = !PIN_READ(PCFX_DATA);
-		++rawDataPtr;
-	} while (--bits > 0);
-}
-
-void PCFXSpy::writeSerial() {
-	sendRawData(rawData, 0, PCFX_BITCOUNT);
-}
-
-void PCFXSpy::debugSerial() {
-	sendRawDataDebug(rawData, 0, PCFX_BITCOUNT);
-}
-#else
-
-void PCFXSpy::loop() {}
-
-void PCFXSpy::writeSerial() {}
-
-void PCFXSpy::debugSerial() {}
-
-void PCFXSpy::updateState() {}
-
-#endif
-
-const char* PCFXSpy::startupMsg()
-{
-	return "PC-FX";
-}
+#define FASTRUN

--- a/firmware/sketches/firmware.ino
+++ b/firmware/sketches/firmware.ino
@@ -164,7 +164,7 @@ void setup()
 #elif defined(RS_VISION) || defined(RS_VISION_CDI)
 	for (int i = A0; i <= A7; ++i)
 		pinMode(i, INPUT_PULLUP);
-#elif !defined(MODE_ATARI_PADDLES) && !defined(MODE_ATARI5200_1) && !defined(MODE_ATARI5200_2) && !defined(MODE_AMIGA_ANALOG_1) && !defined(MODE_AMIGA_ANALOG_2)
+#elif !defined(MODE_ATARI_PADDLES) && !defined(MODE_ATARI5200_1) && !defined(MODE_ATARI5200_2) && !defined(MODE_AMIGA_ANALOG_1) && !defined(MODE_AMIGA_ANALOG_2) && !defined(RASPBERRYPI_PICO)
 	PORTC = 0xFF; // Set the pull-ups on the port we use to check operation mode.
 	DDRC  = 0x00;
 #endif
@@ -201,12 +201,14 @@ void loop()
 		currentSpy->loop();
 }
 
+#if defined(RS_VISION) || defined(RS_VISION_CDI)
 byte ReadAnalog()
 {
 	byte retVal = PINC;
 	
 	return (~retVal  & 0b00111111);
 }
+#endif
 
 #if defined(RS_VISION_ULTRA)
 byte ReadAnalog4()

--- a/firmware/sketches/firmware.ino
+++ b/firmware/sketches/firmware.ino
@@ -161,10 +161,13 @@ void setup()
 	for (int i = 3; i < 9; ++i)
 		if (i != 7)
 			pinMode(i, INPUT_PULLUP);
+#elif defined(RASPBERRYPI_PICO)
+	pinMode(MODEPIN_SNES, INPUT_PULLUP);
+	pinMode(MODEPIN_WII, INPUT_PULLUP);
 #elif defined(RS_VISION) || defined(RS_VISION_CDI)
 	for (int i = A0; i <= A7; ++i)
 		pinMode(i, INPUT_PULLUP);
-#elif !defined(MODE_ATARI_PADDLES) && !defined(MODE_ATARI5200_1) && !defined(MODE_ATARI5200_2) && !defined(MODE_AMIGA_ANALOG_1) && !defined(MODE_AMIGA_ANALOG_2) && !defined(RASPBERRYPI_PICO)
+#elif !defined(MODE_ATARI_PADDLES) && !defined(MODE_ATARI5200_1) && !defined(MODE_ATARI5200_2) && !defined(MODE_AMIGA_ANALOG_1) && !defined(MODE_AMIGA_ANALOG_2)
 	PORTC = 0xFF; // Set the pull-ups on the port we use to check operation mode.
 	DDRC  = 0x00;
 #endif
@@ -410,18 +413,24 @@ bool CreateSpy()
 #elif defined(MODE_DETECT)
 	if (!PINC_READ(MODEPIN_SNES))
 		currentSpy = new SNESSpy;
+#if !defined(RASPBERRYPI_PICO)
 	else if (!PINC_READ(MODEPIN_N64))
 		currentSpy = new N64Spy();
 	else if (!PINC_READ(MODEPIN_GC))
 		currentSpy = new GCSpy();
+#endif
 #if defined(__arm__) && defined(CORE_TEENSY)
 	else if (!PINC_READ(MODEPIN_DREAMCAST))
 		currentSpy = new DreamcastSpy();
+#endif
+#if (defined(__arm__) && defined(CORE_TEENSY)) || defined(RASPBERRYPI_PICO)
 	else if (!PINC_READ(MODEPIN_WII))
 		currentSpy = new WiiSpy();
 #endif 
+#if !defined(RASPBERRYPI_PICO)
 	else
 		currentSpy = new NESSpy();
+#endif
 #elif defined(MODE_NES)
 	currentSpy = new NESSpy();
 #elif defined(MODE_POWERGLOVE)

--- a/firmware/sketches/firmware.ino
+++ b/firmware/sketches/firmware.ino
@@ -193,6 +193,17 @@ void setup()
  
 }
 
+#if defined(RASPBERRYPI_PICO)
+void setup1()
+{
+	ControllerSpy* volatile *p = &currentSpy;
+	while (*p == NULL)
+	{
+	}
+	currentSpy->setup1();
+}
+#endif
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Arduino sketch main loop definition.
 void loop()
@@ -200,6 +211,14 @@ void loop()
 	if (currentSpy != NULL)
 		currentSpy->loop();
 }
+
+#if defined(RASPBERRYPI_PICO)
+void loop1()
+{
+	if (currentSpy != NULL)
+		currentSpy->loop1();
+}
+#endif
 
 #if defined(RS_VISION) || defined(RS_VISION_CDI)
 byte ReadAnalog()


### PR DESCRIPTION
Raspberry Pi Pico allows you to use Wii or SNES Classic controller at a lower cost than Teensy.
Raspberry Pi Pico has two cores, so while one core is processing USB transmissions, the other can focus on reading inputs.
No overclocking is required.