### PR TITLE
Adding french compatibility for axis on Generic Gamepad

### DIFF
--- a/RetroSpyX/Readers/GamepadReader.cs
+++ b/RetroSpyX/Readers/GamepadReader.cs
@@ -79,22 +79,28 @@ namespace RetroSpy.Readers
             {
                 case "Y AXIS":
                 case "Y-ACHSE":
+                case "AXE Y":
                     return "Y";
                 case "X AXIS":
                 case "X-ACHSE":
+                case "AXE X":
                     return "X";
                 case "Y ROTATION":
                 case "Y-ROTATION":
+                case "ROTATION Y":
                     return "RotationY";
                 case "X ROTATION":
                 case "X-ROTATION":
+                case "ROTATION X":
                     return "RotationX";
                 case "Z AXIS":
                 case "Z-ACHSE":
+                case "AXE Z":
                     return "Z";
                 case "Z ROTATION":
                 case "RZ ROTATION":
                 case "Z-ROTATION":
+                case "ROTATION Z":
                     return "RotationZ";
                 default:
                     break;


### PR DESCRIPTION
Hi there,

I had the same issue than #284 but for the french language, so I added the missing data in GamePadReader.cs too.

Tested with a GC Controller plugged with a Wii U GCN Adapater (Driver makes it detected as a vJoy device)

Thank you !